### PR TITLE
Add Support for simple text file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
 This is a chrome extension developed using [Plasmo extension](https://docs.plasmo.com/) project bootstrapped with [`plasmo init`](https://www.npmjs.com/package/plasmo).
 This project is used for auto filling the worklogs at Leapfrog Technology using my own TODO list that I have maintained in emacs org-mode accroding to date.
 
+### Valid tags
+
+```javascript
+:MEETING: :CODING: :OTHER:
+```
+
 **My todo list format** grouped by date
+
+### Org file format: `todo.org`
 
 <a href="https://i.imgur.com/jtqoVTn.png">
 <img src="https://i.imgur.com/jtqoVTn.png" />
 </a>
 
 The **LOGBOOK** is provided by the org mode _clock-in_ and _clock-out_ for tracking the time I worked on that particular task.
+
+### Text file format: `todo.txt`
+
+```text
+# 2022-12-20
+- Work on adding text file :CODING: // adding tag with :TEXT: format
+- Add todo list :OTHER: // everything without tag will automatically treated as other
+- Meeting with client :MEETING:
+
+# 2022-12-21
+- Work on adding org file :CODING: // adding tag with :TEXT: format
+- Add todo list for my party :OTHER: // everything without tag will automatically treated as other
+- Meeting with the client :MEETING:
+```
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ The **LOGBOOK** is provided by the org mode _clock-in_ and _clock-out_ for track
 
 ```text
 # 2022-12-20
-- Work on adding text file :CODING: // adding tag with :TEXT: format
-- Add todo list :OTHER: // everything without tag will automatically treated as other
+- Work on adding a text file :CODING: // adding tag with :TEXT: format
+- Add todo list :OTHER: // everything without a tag will automatically be treated as other
 - Meeting with client :MEETING:
 
 # 2022-12-21
 - Work on adding org file :CODING: // adding tag with :TEXT: format
-- Add todo list for my party :OTHER: // everything without tag will automatically treated as other
+- Add todo list for my party :OTHER: // everything without a tag will automatically be treated as other
 - Meeting with the client :MEETING:
 ```
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 import { baseParse } from 'org-file-parser-with-js'
 
-import { getFormattedOrgLogs } from '~utils/formatLogs'
+import { getFormattedOrgLogs, getFormattedTxtLogs } from '~utils/formatLogs'
 
 const defaultWorkLog = {
   meeting: { tasks: ['- N/A'], time: 0 },
@@ -20,8 +20,7 @@ const fetchData = async (fileURL: string) => {
       const orgJson = baseParse(fileContent)
       return getFormattedOrgLogs(orgJson)
     } else if (fileExtension === 'txt') {
-      // TODO: Implement Formatter for txt file type.
-      // return getFormattedTxtLogs(fileContent)
+      return getFormattedTxtLogs(fileContent)
     }
 
     throw new Error('Invalid File provided')
@@ -34,7 +33,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'refetch') {
     ;(async () => {
       const allResp = await fetchData(request.fileURL)
-      console.log({ allResp })
       sendResponse(allResp[request.date] || defaultWorkLog)
     })()
 

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,1 +1,3 @@
 export const ORG_TIME_STAMP = /^[A-Z][a-z]{2}\s\d{4}\s([A-Z][a-z]+)\s\d{2}/
+export const TXT_TIME_STAMP = /\d{4}\-[0-1]\d\-[0-3]\d/ // YYYY-MM-DD
+export const TODO_TAG = /:[a-zA-Z]+:/

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,3 +1,4 @@
 export const ORG_TIME_STAMP = /^[A-Z][a-z]{2}\s\d{4}\s([A-Z][a-z]+)\s\d{2}/
 export const TXT_TIME_STAMP = /\d{4}\-[0-1]\d\-[0-3]\d/ // YYYY-MM-DD
 export const TODO_TAG = /:[a-zA-Z]+:/
+export const LIST_ITEM_STARTER = /^\-/

--- a/src/utils/formatLogs.ts
+++ b/src/utils/formatLogs.ts
@@ -1,4 +1,4 @@
-import { formatOrgLogs, formattedTaskType } from './formatter'
+import { formatOrgLogs, formatTxtLogs, formattedTaskType } from './formatter'
 
 const populateTaggedTask = (tagObj: any, task: formattedTaskType) => {
   const { content, times = [] } = task
@@ -85,5 +85,12 @@ export const getFormattedOrgLogs = (orgParsedLog: any) => {
   const allTasks = orgParsedLog.children
 
   const formattedTasks = formatOrgLogs(allTasks)
+  return regroupFormattedTasksByTag(formattedTasks)
+}
+
+export const getFormattedTxtLogs = (data: string) => {
+  const allTasks = data.split('\n') // splitting by new line
+
+  const formattedTasks = formatTxtLogs(allTasks)
   return regroupFormattedTasksByTag(formattedTasks)
 }


### PR DESCRIPTION
## Description
Add Support for simple text file.

## Example TODO
```text
# 2022-12-20
- Work on adding text file :CODING: // adding tag with :text: format
- Add todo list :OTHER: // everything without tag will automatically treated as other
- Meeting with client :MEETING:

# 2022-12-21
- Work on adding org file :CODING: // adding tag with :text: format
- Add todo list for my party :OTHER: // everything without tag will automatically treated as other
- Meeting with the client :MEETING:
```