### PR TITLE
Fix the missing addition to existing tag time.

### DIFF
--- a/src/utils/formatLogs.ts
+++ b/src/utils/formatLogs.ts
@@ -10,7 +10,7 @@ const populateTaggedTask = (tagObj: any, task: formattedTaskType) => {
   )
 
   tagObj.tasks.push(content)
-  tagObj.time = +(roundMins(totalTimeInMins) / 60.0).toFixed(2)
+  tagObj.time += +(roundMins(totalTimeInMins) / 60.0).toFixed(2) // add time to time property present in tagObj.
 }
 
 /**


### PR DESCRIPTION
## Description
Fix the missing addition to existing tag time.

## Bug
- The time filled in the time section was of the last item, not the addition of all tasks labeled with tag.